### PR TITLE
Feat/batch errors coerce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-05
+
+### Added
+
+- `errors` keyword on `convert_nic` and `validate_nic`, mirroring
+  `pandas.to_numeric(errors=...)` semantics. `convert_nic` accepts
+  `"raise"` (default), `"coerce"` (replace bad values with `None`), or
+  `"ignore"` (pass the original input through unchanged). `validate_nic`
+  accepts `"raise"` (default) or `"coerce"`; the latter turns previously
+  fatal `dob` / `gender` cross-check failures into per-row
+  `nic.bad_dob_input` / `nic.bad_gender_input` validation errors so a
+  single malformed row no longer aborts the whole batch.
+- `error_col` keyword on `convert_nic` for DataFrame input — adds a
+  per-row error-message column alongside `nic_converted`. Implies
+  `errors="coerce"` when `errors` is left at the default.
+
 ## [0.1.1] - 2026-05-01
 
 ### Added

--- a/docs/validators/nic.md
+++ b/docs/validators/nic.md
@@ -203,9 +203,74 @@ pip install helakit[pandas]   # or [polars], or [pandas,polars]
 ```
 
 `convert_nic` works the same way — pass a DataFrame and `nic_col` and
-get a frame back with a `nic_converted` column. Conversion is strict:
-an invalid value in any row raises `NICFormatError`. Pre-filter with
-`validate_nic` first if you need lenient handling.
+get a frame back with a `nic_converted` column. By default, conversion
+is strict and an invalid value raises `NICFormatError`. See
+**Lenient batch handling** below for `errors="coerce"` and `error_col`.
+
+## Lenient batch handling
+
+By default both batch entry points fail loudly the moment they hit a
+value they cannot interpret — `convert_nic` raises `NICFormatError`,
+and `validate_nic` raises `InvalidInputError` on a bad cross-check
+`dob` / `gender`. That is the right behaviour when bad data is a bug
+in your pipeline, but a hassle when you are auditing a real-world
+file with the usual smattering of typos.
+
+Pass `errors="coerce"` (mirrors `pandas.to_numeric`) to keep going:
+
+```python
+from helakit import convert_nic, validate_nic
+
+# Single bad row no longer kills the whole batch.
+convert_nic(["820149894V", "garbage", "830250995X"], errors="coerce")
+# ["198201409894", None, "198302500995"]
+
+convert_nic(df, nic_col="nic", errors="coerce")
+# garbage rows get None in nic_converted
+
+# Same idea, but keep the original string instead of None:
+convert_nic(df, nic_col="nic", errors="ignore")
+```
+
+`validate_nic` accepts `errors="raise"` (default) and `errors="coerce"`.
+Coerce mode catches unparseable `dob` / `gender` values and turns them
+into per-row `nic.bad_dob_input` / `nic.bad_gender_input` errors:
+
+```python
+df = pd.DataFrame({
+    "nic":    ["820149894V", "820149894V", "199201409894"],
+    "dob":    ["1982-01-14", "not a date", "1992-03-14"],
+    "gender": ["M",          "alien",      "F"],
+})
+
+batch = validate_nic(
+    df,
+    nic_col="nic",
+    dob_col="dob",
+    gender_col="gender",
+    errors="coerce",
+)
+batch.summary.invalid          # 1
+batch.df["nic_errors"].iloc[1] # "nic.bad_dob_input,nic.bad_gender_input"
+```
+
+### Capturing failures in a separate column
+
+For `convert_nic` on DataFrames, pass `error_col` to add a per-row
+error-message column alongside `nic_converted`. It implies
+`errors="coerce"` unless you set `errors` explicitly:
+
+```python
+out = convert_nic(df, nic_col="nic", error_col="nic_error")
+out[["nic_converted", "nic_error"]]
+#   nic_converted   nic_error
+# 0 198201409894    None
+# 1 None            Cannot convert 'garbage' — input is not a valid old NIC (...)
+```
+
+`validate_nic` already exposes failures through the `nic_errors`
+column on DataFrame output, so a separate `error_col` is unnecessary
+there.
 
 ## Encoding details
 
@@ -248,3 +313,5 @@ Validation failures are reported via `result.errors` — a list of
 | `nic.invalid_date`    | Day code does not yield a real date in the given year.   |
 | `nic.format_mismatch` | Format hint (`old` / `new`) didn't match the input.      |
 | `nic.not_a_string`    | A row in a batch supplied a non-string NIC.              |
+| `nic.bad_dob_input`   | Cross-check `dob` was unparseable; only emitted with `errors="coerce"`. |
+| `nic.bad_gender_input`| Cross-check `gender` was unparseable; only emitted with `errors="coerce"`. |

--- a/src/helakit/__init__.py
+++ b/src/helakit/__init__.py
@@ -15,7 +15,7 @@ from helakit.nic import (
 from helakit.phone import is_valid_phone, validate_phone
 from helakit.postal import is_valid_postal, validate_postal
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 __all__ = [
     "HelakitError",

--- a/src/helakit/nic/converter.py
+++ b/src/helakit/nic/converter.py
@@ -87,9 +87,7 @@ def convert_nic(
             ``errors`` values.
     """
     if errors not in _VALID_ERROR_MODES:
-        raise InvalidInputError(
-            f"errors must be one of {_VALID_ERROR_MODES}; got {errors!r}."
-        )
+        raise InvalidInputError(f"errors must be one of {_VALID_ERROR_MODES}; got {errors!r}.")
 
     kind = detect_kind(value)
     if kind == "str":

--- a/src/helakit/nic/converter.py
+++ b/src/helakit/nic/converter.py
@@ -8,7 +8,7 @@ format: pass a 12-digit NIC and you get the same NIC back.
 
 from __future__ import annotations
 
-from typing import Any, overload
+from typing import Any, Literal, overload
 
 from helakit._core.exceptions import InvalidInputError
 from helakit.nic._data import DEFAULT_OLD_NIC_CENTURY, NEW_FORMAT_LENGTH
@@ -17,17 +17,32 @@ from helakit.nic._normalize import normalize
 from helakit.nic._parse import parse
 from helakit.nic.exceptions import NICFormatError
 
+ErrorMode = Literal["raise", "coerce", "ignore"]
+_VALID_ERROR_MODES: tuple[ErrorMode, ...] = ("raise", "coerce", "ignore")
+
 
 @overload
 def convert_nic(value: str, *, century: int = ...) -> str: ...
 
 
 @overload
-def convert_nic(value: list[str] | tuple[str, ...], *, century: int = ...) -> list[str]: ...
+def convert_nic(
+    value: list[str] | tuple[str, ...],
+    *,
+    century: int = ...,
+    errors: ErrorMode = ...,
+) -> list[str | None]: ...
 
 
 @overload
-def convert_nic(value: Any, *, century: int = ..., nic_col: str | None = ...) -> Any: ...
+def convert_nic(
+    value: Any,
+    *,
+    century: int = ...,
+    nic_col: str | None = ...,
+    errors: ErrorMode = ...,
+    error_col: str | None = ...,
+) -> Any: ...
 
 
 def convert_nic(
@@ -35,6 +50,8 @@ def convert_nic(
     *,
     century: int = DEFAULT_OLD_NIC_CENTURY,
     nic_col: str | None = None,
+    errors: ErrorMode = "raise",
+    error_col: str | None = None,
 ) -> Any:
     """Convert an old-format NIC to the new 12-digit format.
 
@@ -45,6 +62,18 @@ def convert_nic(
             copy of the frame with a new ``nic_converted`` column added.
         century: Century to assume for two-digit years on old NICs.
         nic_col: Required for tabular input.
+        errors: How to handle individual values that cannot be converted.
+            ``"raise"`` (default) propagates :class:`NICFormatError` on
+            the first bad value — same as ``pandas`` strict mode.
+            ``"coerce"`` replaces bad values with ``None`` so a single
+            malformed row no longer fails the whole batch. ``"ignore"``
+            leaves the original input through untouched. Scalar input
+            always raises regardless of this setting.
+        error_col: Column name for per-row error messages (DataFrame
+            input only). When supplied, the returned frame gets an extra
+            column with the failure message or ``None`` for rows that
+            converted cleanly. Implies ``errors="coerce"`` if ``errors``
+            is left at the default of ``"raise"``.
 
     Returns:
         The same shape as the input — string for string, list for list,
@@ -52,19 +81,37 @@ def convert_nic(
 
     Raises:
         NICFormatError: If a value cannot be parsed (e.g. wrong length,
-            non-numeric content). New-format input passes through
-            unchanged.
-        InvalidInputError: For unsupported input types.
+            non-numeric content) and ``errors="raise"``. New-format input
+            passes through unchanged.
+        InvalidInputError: For unsupported input types or invalid
+            ``errors`` values.
     """
+    if errors not in _VALID_ERROR_MODES:
+        raise InvalidInputError(
+            f"errors must be one of {_VALID_ERROR_MODES}; got {errors!r}."
+        )
+
     kind = detect_kind(value)
     if kind == "str":
+        if error_col is not None:
+            raise InvalidInputError("error_col only applies to batch input.")
         return _convert_one(value, century=century)
+
+    effective_errors: ErrorMode = (
+        "coerce" if (error_col is not None and errors == "raise") else errors
+    )
+
     if kind == "list_of_str":
-        return [_convert_one(v, century=century) for v in value]
+        if error_col is not None:
+            raise InvalidInputError(
+                "error_col only applies to DataFrame input. For lists, inspect the "
+                "returned values directly or use validate_nic for per-row diagnostics."
+            )
+        return [_convert_with_mode(v, century=century, errors=effective_errors)[0] for v in value]
     if kind == "pandas":
-        return _convert_pandas(value, nic_col, century)
+        return _convert_pandas(value, nic_col, century, effective_errors, error_col)
     if kind == "polars":
-        return _convert_polars(value, nic_col, century)
+        return _convert_polars(value, nic_col, century, effective_errors, error_col)
     raise InvalidInputError(f"convert_nic does not accept input of kind {kind!r}.")
 
 
@@ -83,22 +130,78 @@ def _convert_one(value: str, *, century: int) -> str:
     return f"{parsed.year:04d}{parsed.raw_day_code:03d}0{parsed.serial:03d}{parsed.check_digit}"
 
 
-def _convert_pandas(df: Any, nic_col: str | None, century: int) -> Any:
+def _convert_with_mode(
+    value: Any,
+    *,
+    century: int,
+    errors: ErrorMode,
+) -> tuple[Any, str | None]:
+    """Convert one value under a batch error mode.
+
+    Returns ``(converted_value, error_message)``. For successful conversions
+    the error message is ``None``; for failures the value reflects the
+    chosen mode (``None`` for coerce, the original input for ignore).
+    """
+    if not isinstance(value, str):
+        if errors == "raise":
+            raise NICFormatError(
+                f"Cannot convert {value!r} — expected a string, got {type(value).__name__}."
+            )
+        message = f"expected a string, got {type(value).__name__}"
+        return (None if errors == "coerce" else value, message)
+
+    try:
+        return (_convert_one(value, century=century), None)
+    except NICFormatError as exc:
+        if errors == "raise":
+            raise
+        return (None if errors == "coerce" else value, str(exc))
+
+
+def _convert_pandas(
+    df: Any,
+    nic_col: str | None,
+    century: int,
+    errors: ErrorMode,
+    error_col: str | None,
+) -> Any:
     if nic_col is None:
         raise InvalidInputError("nic_col is required when converting a DataFrame.")
     if nic_col not in df.columns:
         raise InvalidInputError(f"Column {nic_col!r} not found. Available: {sorted(df.columns)}.")
+    converted: list[Any] = []
+    error_messages: list[str | None] = []
+    for raw in df[nic_col].tolist():
+        value, message = _convert_with_mode(raw, century=century, errors=errors)
+        converted.append(value)
+        error_messages.append(message)
     annotated = df.copy()
-    annotated["nic_converted"] = [_convert_one(v, century=century) for v in df[nic_col].tolist()]
+    annotated["nic_converted"] = converted
+    if error_col is not None:
+        annotated[error_col] = error_messages
     return annotated
 
 
-def _convert_polars(df: Any, nic_col: str | None, century: int) -> Any:
+def _convert_polars(
+    df: Any,
+    nic_col: str | None,
+    century: int,
+    errors: ErrorMode,
+    error_col: str | None,
+) -> Any:
     if nic_col is None:
         raise InvalidInputError("nic_col is required when converting a DataFrame.")
     if nic_col not in df.columns:
         raise InvalidInputError(f"Column {nic_col!r} not found. Available: {sorted(df.columns)}.")
     import polars as pl
 
-    converted = [_convert_one(v, century=century) for v in df[nic_col].to_list()]
-    return df.with_columns(pl.Series("nic_converted", converted))
+    converted: list[Any] = []
+    error_messages: list[str | None] = []
+    for raw in df[nic_col].to_list():
+        value, message = _convert_with_mode(raw, century=century, errors=errors)
+        converted.append(value)
+        error_messages.append(message)
+    new_columns = [pl.Series("nic_converted", converted, dtype=pl.Utf8)]
+    if error_col is not None:
+        new_columns.append(pl.Series(error_col, error_messages, dtype=pl.Utf8))
+    return df.with_columns(new_columns)

--- a/src/helakit/nic/validator.py
+++ b/src/helakit/nic/validator.py
@@ -29,6 +29,8 @@ from helakit.nic._parse import ParsedNIC, parse
 from helakit.nic._types import NICBatchResult, NICDecoded, NICSummary
 
 FormatHint = Literal["old", "new", "any"]
+BatchErrorMode = Literal["raise", "coerce"]
+_VALID_BATCH_ERROR_MODES: tuple[BatchErrorMode, ...] = ("raise", "coerce")
 
 
 @overload
@@ -49,6 +51,7 @@ def validate_nic(
     dob_col: str | None = ...,
     gender_col: str | None = ...,
     century: int = ...,
+    errors: BatchErrorMode = ...,
 ) -> NICBatchResult: ...
 
 
@@ -61,6 +64,7 @@ def validate_nic(
     dob_col: str | None = ...,
     gender_col: str | None = ...,
     century: int = ...,
+    errors: BatchErrorMode = ...,
 ) -> NICBatchResult: ...
 
 
@@ -72,6 +76,7 @@ def validate_nic(
     dob_col: str | None = None,
     gender_col: str | None = None,
     century: int = DEFAULT_OLD_NIC_CENTURY,
+    errors: BatchErrorMode = "raise",
 ) -> ValidationResult | NICBatchResult:
     """Validate one or many Sri Lankan NIC numbers.
 
@@ -88,15 +93,28 @@ def validate_nic(
             ``Female``, case-insensitive).
         century: Century to assume for two-digit years on old NICs.
             Defaults to ``1900``.
+        errors: Batch-only. ``"raise"`` (default) propagates
+            :class:`InvalidInputError` if any cross-check ``dob`` or
+            ``gender`` value is unparseable, matching strict pandas
+            semantics. ``"coerce"`` records the failure as a per-row
+            error in :attr:`ValidationResult.errors` (and the
+            ``nic_errors`` column on DataFrame output) so a single
+            malformed row no longer aborts the whole batch.
 
     Returns:
         A :class:`ValidationResult` for scalar input, or a
         :class:`NICBatchResult` for any iterable input.
 
     Raises:
-        InvalidInputError: For unsupported input types or unparseable
-            gender / DOB values.
+        InvalidInputError: For unsupported input types, an invalid
+            ``errors`` value, or unparseable gender / DOB values when
+            ``errors="raise"``.
     """
+    if errors not in _VALID_BATCH_ERROR_MODES:
+        raise InvalidInputError(
+            f"errors must be one of {_VALID_BATCH_ERROR_MODES}; got {errors!r}."
+        )
+
     kind = detect_kind(data)
     if kind == "str":
         return _validate_one(data, format=format, century=century)
@@ -117,6 +135,7 @@ def validate_nic(
         gender_col=gender_col,
         format=format,
         century=century,
+        errors=errors,
     )
 
 
@@ -242,6 +261,23 @@ def _cross_check(
     return extras
 
 
+def _coerce_optional(
+    coercer: Any,
+    value: Any,
+    *,
+    field: str,
+    code: str,
+    errors: BatchErrorMode,
+) -> tuple[Any, ValidationError | None]:
+    """Run a cross-check coercer, raising or capturing failures per the mode."""
+    if errors == "raise":
+        return coercer(value), None
+    try:
+        return coercer(value), None
+    except InvalidInputError as exc:
+        return None, ValidationError(code=code, message=str(exc), field=field)
+
+
 def _age(dob: date, *, today: date | None = None) -> int:
     today = today or date.today()
     years = today.year - dob.year
@@ -332,6 +368,7 @@ def _validate_batch(
     gender_col: str | None,
     format: FormatHint,
     century: int,
+    errors: BatchErrorMode,
 ) -> NICBatchResult:
     results: list[ValidationResult] = []
     normalized_index: dict[str, list[int]] = {}
@@ -355,8 +392,22 @@ def _validate_batch(
             )
             continue
 
-        expected_dob = coerce_dob(row.get("dob")) if dob_col else None
-        expected_gender = coerce_gender(row.get("gender")) if gender_col else None
+        expected_dob, dob_error = _coerce_optional(
+            coerce_dob,
+            row.get("dob"),
+            field="dob",
+            code="nic.bad_dob_input",
+            errors=errors,
+        ) if dob_col else (None, None)
+        expected_gender, gender_error = _coerce_optional(
+            coerce_gender,
+            row.get("gender"),
+            field="gender",
+            code="nic.bad_gender_input",
+            errors=errors,
+        ) if gender_col else (None, None)
+
+        coercion_errors = [e for e in (dob_error, gender_error) if e is not None]
 
         result = _validate_one(
             raw_nic,
@@ -365,6 +416,14 @@ def _validate_batch(
             expected_dob=expected_dob,
             expected_gender=expected_gender,
         )
+        if coercion_errors:
+            result = ValidationResult(
+                is_valid=False,
+                value=result.value,
+                normalized=result.normalized,
+                errors=[*result.errors, *coercion_errors],
+                data=result.data,
+            )
         results.append(result)
 
         if result.normalized is not None:

--- a/src/helakit/nic/validator.py
+++ b/src/helakit/nic/validator.py
@@ -392,20 +392,28 @@ def _validate_batch(
             )
             continue
 
-        expected_dob, dob_error = _coerce_optional(
-            coerce_dob,
-            row.get("dob"),
-            field="dob",
-            code="nic.bad_dob_input",
-            errors=errors,
-        ) if dob_col else (None, None)
-        expected_gender, gender_error = _coerce_optional(
-            coerce_gender,
-            row.get("gender"),
-            field="gender",
-            code="nic.bad_gender_input",
-            errors=errors,
-        ) if gender_col else (None, None)
+        expected_dob, dob_error = (
+            _coerce_optional(
+                coerce_dob,
+                row.get("dob"),
+                field="dob",
+                code="nic.bad_dob_input",
+                errors=errors,
+            )
+            if dob_col
+            else (None, None)
+        )
+        expected_gender, gender_error = (
+            _coerce_optional(
+                coerce_gender,
+                row.get("gender"),
+                field="gender",
+                code="nic.bad_gender_input",
+                errors=errors,
+            )
+            if gender_col
+            else (None, None)
+        )
 
         coercion_errors = [e for e in (dob_error, gender_error) if e is not None]
 

--- a/tests/test_nic/test_batch.py
+++ b/tests/test_nic/test_batch.py
@@ -165,9 +165,7 @@ def test_errors_coerce_captures_bad_dob_per_row() -> None:
 
 def test_errors_coerce_captures_both_dob_and_gender() -> None:
     rows = [{"nic": "820149894V", "dob": "bogus", "gender": "alien"}]
-    batch = validate_nic(
-        rows, nic_col="nic", dob_col="dob", gender_col="gender", errors="coerce"
-    )
+    batch = validate_nic(rows, nic_col="nic", dob_col="dob", gender_col="gender", errors="coerce")
     codes = {e.code for e in batch.results[0].errors}
     assert {"nic.bad_dob_input", "nic.bad_gender_input"} <= codes
 

--- a/tests/test_nic/test_batch.py
+++ b/tests/test_nic/test_batch.py
@@ -134,3 +134,50 @@ def test_batch_handles_non_string_input() -> None:
     batch = validate_nic([{"nic": 12345}], nic_col="nic")
     assert not batch.results[0].is_valid
     assert batch.results[0].errors[0].code == "nic.not_a_string"
+
+
+def test_errors_coerce_captures_bad_gender_per_row() -> None:
+    rows = [
+        {"nic": "820149894V", "gender": "M"},
+        {"nic": "820149894V", "gender": "other"},
+        {"nic": "820149894V", "gender": "F"},
+    ]
+    batch = validate_nic(rows, nic_col="nic", gender_col="gender", errors="coerce")
+    assert batch.results[0].is_valid
+    assert not batch.results[1].is_valid
+    bad_codes = [e.code for e in batch.results[1].errors]
+    assert "nic.bad_gender_input" in bad_codes
+    # Third row should still process even though row 2 was bad.
+    assert batch.results[2].data["gender_match"] is False
+
+
+def test_errors_coerce_captures_bad_dob_per_row() -> None:
+    rows = [
+        {"nic": "820149894V", "dob": "not a date"},
+        {"nic": "820149894V", "dob": "1982-01-14"},
+    ]
+    batch = validate_nic(rows, nic_col="nic", dob_col="dob", errors="coerce")
+    assert not batch.results[0].is_valid
+    codes = [e.code for e in batch.results[0].errors]
+    assert "nic.bad_dob_input" in codes
+    assert batch.results[1].data["dob_match"] is True
+
+
+def test_errors_coerce_captures_both_dob_and_gender() -> None:
+    rows = [{"nic": "820149894V", "dob": "bogus", "gender": "alien"}]
+    batch = validate_nic(
+        rows, nic_col="nic", dob_col="dob", gender_col="gender", errors="coerce"
+    )
+    codes = {e.code for e in batch.results[0].errors}
+    assert {"nic.bad_dob_input", "nic.bad_gender_input"} <= codes
+
+
+def test_errors_invalid_value_rejected() -> None:
+    with pytest.raises(InvalidInputError):
+        validate_nic(["820149894V"], errors="silently-fail")  # type: ignore[arg-type]
+
+
+def test_errors_raise_default_still_propagates() -> None:
+    rows = [{"nic": "820149894V", "gender": "other"}]
+    with pytest.raises(InvalidInputError):
+        validate_nic(rows, nic_col="nic", gender_col="gender")

--- a/tests/test_nic/test_converter.py
+++ b/tests/test_nic/test_converter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from helakit import NICFormatError, convert_nic
+from helakit import InvalidInputError, NICFormatError, convert_nic
 
 
 def test_old_to_new() -> None:
@@ -41,4 +41,47 @@ def test_list_of_strings() -> None:
     assert convert_nic(["820149894V", "830250995X"]) == [
         "198201409894",
         "198302500995",
+    ]
+
+
+def test_list_default_raises_on_first_bad_value() -> None:
+    with pytest.raises(NICFormatError):
+        convert_nic(["820149894V", "garbage"])
+
+
+def test_list_errors_coerce_replaces_bad_values_with_none() -> None:
+    assert convert_nic(["820149894V", "garbage", "830250995X"], errors="coerce") == [
+        "198201409894",
+        None,
+        "198302500995",
+    ]
+
+
+def test_list_errors_ignore_keeps_originals() -> None:
+    assert convert_nic(["820149894V", "garbage"], errors="ignore") == [
+        "198201409894",
+        "garbage",
+    ]
+
+
+def test_list_errors_invalid_value_raises() -> None:
+    with pytest.raises(InvalidInputError):
+        convert_nic(["820149894V"], errors="silently-fail")  # type: ignore[arg-type]
+
+
+def test_list_error_col_rejected() -> None:
+    with pytest.raises(InvalidInputError):
+        convert_nic(["820149894V"], error_col="err")
+
+
+def test_scalar_error_col_rejected() -> None:
+    with pytest.raises(InvalidInputError):
+        convert_nic("820149894V", error_col="err")
+
+
+def test_list_coerce_handles_non_string_input() -> None:
+    assert convert_nic(["820149894V", None, 42], errors="coerce") == [  # type: ignore[list-item]
+        "198201409894",
+        None,
+        None,
     ]

--- a/tests/test_nic/test_dataframes.py
+++ b/tests/test_nic/test_dataframes.py
@@ -76,9 +76,7 @@ def test_pandas_validate_errors_coerce_survives_bad_row() -> None:
             "gender": ["M", "alien", "F"],
         }
     )
-    batch = validate_nic(
-        df, nic_col="nic", dob_col="dob", gender_col="gender", errors="coerce"
-    )
+    batch = validate_nic(df, nic_col="nic", dob_col="dob", gender_col="gender", errors="coerce")
     assert batch.df is not None
     assert batch.df["nic_valid"].tolist() == [True, False, True]
     bad_codes = batch.df["nic_errors"].tolist()[1]

--- a/tests/test_nic/test_dataframes.py
+++ b/tests/test_nic/test_dataframes.py
@@ -68,6 +68,35 @@ def test_pandas_missing_column_raises() -> None:
         validate_nic(df, nic_col="nic", dob_col="missing")
 
 
+def test_pandas_validate_errors_coerce_survives_bad_row() -> None:
+    df = pd.DataFrame(
+        {
+            "nic": ["820149894V", "820149894V", "199201409894"],
+            "dob": ["1982-01-14", "not a date", "1992-03-14"],
+            "gender": ["M", "alien", "F"],
+        }
+    )
+    batch = validate_nic(
+        df, nic_col="nic", dob_col="dob", gender_col="gender", errors="coerce"
+    )
+    assert batch.df is not None
+    assert batch.df["nic_valid"].tolist() == [True, False, True]
+    bad_codes = batch.df["nic_errors"].tolist()[1]
+    assert "nic.bad_dob_input" in bad_codes
+    assert "nic.bad_gender_input" in bad_codes
+
+
+def test_pandas_validate_default_errors_raise_on_bad_row() -> None:
+    df = pd.DataFrame(
+        {
+            "nic": ["820149894V"],
+            "dob": ["not a date"],
+        }
+    )
+    with pytest.raises(InvalidInputError):
+        validate_nic(df, nic_col="nic", dob_col="dob")
+
+
 def test_pandas_handles_nan_dob() -> None:
     df = pd.DataFrame({"nic": ["820149894V"], "dob": [float("nan")]})
     batch = validate_nic(df, nic_col="nic", dob_col="dob")
@@ -110,7 +139,10 @@ def test_pandas_convert_propagates_invalid() -> None:
 def test_pandas_convert_errors_coerce() -> None:
     df = pd.DataFrame({"nic": ["820149894V", "garbage", "830250995X"]})
     out = convert_nic(df, nic_col="nic", errors="coerce")
-    assert out["nic_converted"].tolist() == ["198201409894", None, "198302500995"]
+    converted = out["nic_converted"].tolist()
+    assert converted[0] == "198201409894"
+    assert pd.isna(converted[1])
+    assert converted[2] == "198302500995"
 
 
 def test_pandas_convert_errors_ignore() -> None:
@@ -122,9 +154,11 @@ def test_pandas_convert_errors_ignore() -> None:
 def test_pandas_convert_error_col_implies_coerce() -> None:
     df = pd.DataFrame({"nic": ["820149894V", "garbage"]})
     out = convert_nic(df, nic_col="nic", error_col="nic_error")
-    assert out["nic_converted"].tolist() == ["198201409894", None]
+    converted = out["nic_converted"].tolist()
+    assert converted[0] == "198201409894"
+    assert pd.isna(converted[1])
     errors = out["nic_error"].tolist()
-    assert errors[0] is None
+    assert pd.isna(errors[0])
     assert isinstance(errors[1], str) and "garbage" in errors[1]
 
 
@@ -132,7 +166,7 @@ def test_pandas_convert_error_col_with_explicit_ignore() -> None:
     df = pd.DataFrame({"nic": ["820149894V", "garbage"]})
     out = convert_nic(df, nic_col="nic", errors="ignore", error_col="nic_error")
     assert out["nic_converted"].tolist() == ["198201409894", "garbage"]
-    assert out["nic_error"].iloc[0] is None
+    assert pd.isna(out["nic_error"].iloc[0])
     assert "garbage" in out["nic_error"].iloc[1]
 
 

--- a/tests/test_nic/test_dataframes.py
+++ b/tests/test_nic/test_dataframes.py
@@ -107,6 +107,42 @@ def test_pandas_convert_propagates_invalid() -> None:
         convert_nic(df, nic_col="nic")
 
 
+def test_pandas_convert_errors_coerce() -> None:
+    df = pd.DataFrame({"nic": ["820149894V", "garbage", "830250995X"]})
+    out = convert_nic(df, nic_col="nic", errors="coerce")
+    assert out["nic_converted"].tolist() == ["198201409894", None, "198302500995"]
+
+
+def test_pandas_convert_errors_ignore() -> None:
+    df = pd.DataFrame({"nic": ["820149894V", "garbage"]})
+    out = convert_nic(df, nic_col="nic", errors="ignore")
+    assert out["nic_converted"].tolist() == ["198201409894", "garbage"]
+
+
+def test_pandas_convert_error_col_implies_coerce() -> None:
+    df = pd.DataFrame({"nic": ["820149894V", "garbage"]})
+    out = convert_nic(df, nic_col="nic", error_col="nic_error")
+    assert out["nic_converted"].tolist() == ["198201409894", None]
+    errors = out["nic_error"].tolist()
+    assert errors[0] is None
+    assert isinstance(errors[1], str) and "garbage" in errors[1]
+
+
+def test_pandas_convert_error_col_with_explicit_ignore() -> None:
+    df = pd.DataFrame({"nic": ["820149894V", "garbage"]})
+    out = convert_nic(df, nic_col="nic", errors="ignore", error_col="nic_error")
+    assert out["nic_converted"].tolist() == ["198201409894", "garbage"]
+    assert out["nic_error"].iloc[0] is None
+    assert "garbage" in out["nic_error"].iloc[1]
+
+
+def test_pandas_convert_does_not_mutate_input() -> None:
+    df = pd.DataFrame({"nic": ["820149894V", "garbage"]})
+    convert_nic(df, nic_col="nic", errors="coerce", error_col="nic_error")
+    assert "nic_converted" not in df.columns
+    assert "nic_error" not in df.columns
+
+
 def test_polars_convert_appends_column() -> None:
     df = pl.DataFrame({"nic": ["820149894V"]})
     out = convert_nic(df, nic_col="nic")
@@ -117,6 +153,21 @@ def test_polars_convert_requires_nic_col() -> None:
     df = pl.DataFrame({"nic": ["820149894V"]})
     with pytest.raises(InvalidInputError):
         convert_nic(df)
+
+
+def test_polars_convert_errors_coerce() -> None:
+    df = pl.DataFrame({"nic": ["820149894V", "garbage"]})
+    out = convert_nic(df, nic_col="nic", errors="coerce")
+    assert out["nic_converted"].to_list() == ["198201409894", None]
+
+
+def test_polars_convert_error_col_populated() -> None:
+    df = pl.DataFrame({"nic": ["820149894V", "garbage"]})
+    out = convert_nic(df, nic_col="nic", error_col="nic_error")
+    assert out["nic_converted"].to_list() == ["198201409894", None]
+    errors = out["nic_error"].to_list()
+    assert errors[0] is None
+    assert isinstance(errors[1], str) and "garbage" in errors[1]
 
 
 def test_pandas_decoded_dob_is_real_date() -> None:


### PR DESCRIPTION
### Summary

What does this change and why?

Added error corcing to  the nic_convertion in dataframes

### Checklist

- [ yes] Tests added or updated
- [ yes] Docs updated (where user-visible)
- [ yes] `CHANGELOG.md` entry added under `[Unreleased]`
- [yes] `uv run ruff check .` passes
- [ yes] `uv run ruff format --check .` passes
- [ yes] `uv run mypy src` passes
- [yes ] `uv run pytest` passes


