### PR TITLE
Add remaining Sri Lankan districts and provinces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-08-09
+
+### Added
+
+- `PROVINCES` now includes all 9 provinces of Sri Lanka (previously only
+  Western, Central, and Southern). `DISTRICTS` now includes all 25
+  districts (previously only Colombo, Kandy, and Galle). Sourced from the
+  Department of Census and Statistics and Wikipedia's list of Sri Lankan
+  districts/provinces.
+
 ## [0.3.0] - 2026-07-06
 
 ### Added

--- a/src/helakit/_data/districts.py
+++ b/src/helakit/_data/districts.py
@@ -1,7 +1,8 @@
 """Districts of Sri Lanka, keyed by short code.
 
-Placeholder data — the remaining districts will be added alongside the
-postal-code validator.
+Sources:
+    - Department of Census and Statistics, Sri Lanka:
+      http://www.statistics.gov.lk/
 """
 
 from __future__ import annotations
@@ -9,7 +10,38 @@ from __future__ import annotations
 from typing import Final
 
 DISTRICTS: Final[dict[str, str]] = {
+    # Western Province
     "CMB": "Colombo",
+    "GMP": "Gampaha",
+    "KAL": "Kalutara",
+    # Central Province
     "KAN": "Kandy",
+    "MTL": "Matale",
+    "NUE": "Nuwara Eliya",
+    # Southern Province
     "GAL": "Galle",
+    "MAT": "Matara",
+    "HAM": "Hambantota",
+    # Northern Province
+    "JAF": "Jaffna",
+    "KIL": "Kilinochchi",
+    "MAN": "Mannar",
+    "VAV": "Vavuniya",
+    "MUL": "Mullaitivu",
+    # Eastern Province
+    "TRI": "Trincomalee",
+    "BAT": "Batticaloa",
+    "AMP": "Ampara",
+    # North Western Province
+    "KUR": "Kurunegala",
+    "PUT": "Puttalam",
+    # North Central Province
+    "ANU": "Anuradhapura",
+    "POL": "Polonnaruwa",
+    # Uva Province
+    "BAD": "Badulla",
+    "MON": "Monaragala",
+    # Sabaragamuwa Province
+    "RAT": "Ratnapura",
+    "KEG": "Kegalle",
 }

--- a/src/helakit/_data/provinces.py
+++ b/src/helakit/_data/provinces.py
@@ -1,7 +1,8 @@
 """Provinces of Sri Lanka, keyed by short code.
 
-Placeholder data — the remaining provinces will be added alongside the
-postal-code validator.
+Sources:
+    - Department of Census and Statistics, Sri Lanka:
+      http://www.statistics.gov.lk/
 """
 
 from __future__ import annotations
@@ -12,4 +13,10 @@ PROVINCES: Final[dict[str, str]] = {
     "WP": "Western",
     "CP": "Central",
     "SP": "Southern",
+    "NP": "Northern",
+    "EP": "Eastern",
+    "NW": "North Western",
+    "NC": "North Central",
+    "UP": "Uva",
+    "SG": "Sabaragamuwa",
 }


### PR DESCRIPTION
Fills in the placeholder lookup tables in `src/helakit/_data/`:

- `DISTRICTS` — was 3 of 25 districts (Colombo, Kandy, Galle). Now all 25.
- `PROVINCES` — was 3 of 9 provinces (Western, Central, Southern). Now all 9.

Both files were previously marked "Placeholder data — the remaining
districts/provinces will be added alongside the postal-code validator."
This closes that gap ahead of `validate_postal` being implemented.